### PR TITLE
allow specifing ecma version

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -57,6 +57,11 @@ const PASSTHROUGH_EXPORTS = {
 
 const IGNORE_IMPORT_PREFIXES = ["data:", "node:"];
 
+
+// default ECMA version passed to acorn
+// matches acorn@2.0.1 default
+const DEFAULT_ECMA_VERSION = 2020;
+
 // Helpers
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
@@ -176,6 +181,7 @@ const _recurseDeps = async ({
   allowMissing = {},
   bailOnMissing = true,
   includeSourceMaps = false,
+  ecmaVersion,
   _extraImports,
   _tracedDepPaths
 }) => {
@@ -206,6 +212,7 @@ const _recurseDeps = async ({
         allowMissing,
         bailOnMissing,
         includeSourceMaps,
+        ecmaVersion,
         _extraImports,
         _tracedDepPaths
       });
@@ -491,6 +498,7 @@ const _resolveDep = async ({
  * @param {boolean}       opts.bailOnMissing      allow static dependencies to be missing
  * @param {boolean}       opts.includeSourceMaps  include source map paths in output
  * @param {Object}        opts.extraImports       map files to additional imports to trace
+ * @param {Object}        opts.ecmaVersion        ECMAScript version to be passed to acorn
  * @param {Object}        opts._extraImports      (internal) normalized map
  * @param {Set}           opts._tracedDepPaths    (internal) tracked dependencies
  * @returns {Promise<Object>}                     dependencies and other information
@@ -503,6 +511,7 @@ const traceFile = async ({
   bailOnMissing = true,
   includeSourceMaps = false,
   extraImports = {},
+  ecmaVersion = DEFAULT_ECMA_VERSION,
   _extraImports,
   _tracedDepPaths = new Set()
 } = {}) => {
@@ -537,12 +546,13 @@ const traceFile = async ({
       sourceType: "module",
       allowAwaitOutsideFunction: true, // for top-level await
       locations: true,
-      onComment
+      onComment,
+      ecmaVersion
     });
   } catch (modErr) {
     // Then as script.
     try {
-      ast = parse(src, { sourceType: "script", locations: true, onComment });
+      ast = parse(src, { sourceType: "script", locations: true, onComment, ecmaVersion });
     } catch (scriptErr) {
       // Use original module error, with some helper errors.
       throw new Error(`Encountered parse error in ${srcPath}: ${modErr}`);
@@ -627,6 +637,7 @@ const traceFile = async ({
     allowMissing,
     bailOnMissing,
     includeSourceMaps,
+    ecmaVersion,
     _extraImports,
     _tracedDepPaths
   });
@@ -658,6 +669,7 @@ const traceFile = async ({
  * @param {boolean}       opts.bailOnMissing      allow static dependencies to be missing
  * @param {boolean}       opts.includeSourceMaps  include source map paths in output
  * @param {Object}        opts.extraImports       map files to additional imports to trace
+ * @param {Object}        opts.ecmaVersion        ECMAScript version to be passed to acorn
  * @param {Object}        opts._extraImports      (internal) normalized map
  * @param {Set}           opts._tracedDepPaths    (internal) tracked dependencies
  * @returns {Promise<Object>}                     dependencies and other information
@@ -669,6 +681,7 @@ const traceFiles = async ({
   bailOnMissing = true,
   includeSourceMaps = false,
   extraImports = {},
+  ecmaVersion = DEFAULT_ECMA_VERSION,
   _extraImports,
   _tracedDepPaths = new Set()
 } = {}) => {
@@ -681,6 +694,7 @@ const traceFiles = async ({
     allowMissing,
     bailOnMissing,
     includeSourceMaps,
+    ecmaVersion,
     _extraImports,
     _tracedDepPaths
   });


### PR DESCRIPTION
acorn-node@2.0.1 uses ecmaVersion = 2020, what's causing troubles when working with code written for NodeJS@16 (e.g. lack of support for ??= operator).

I added config option to overwrite default value. Unfortunatelly if ecmaVersion property is passed it has to be defined, so added constant with default value (2020) as well